### PR TITLE
Fix UHF NMR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+#FIXME: workflow dependency not working on non-default branch?
+#on:
+#  workflow_run:
+#    workflows:
+#      - Lint
+#    types:
+#      - completed
+on:
+  - push
+  - pull_request
+
+jobs:
+  linux-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10","3.12"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: ./.github/workflows/run_ci.sh
+      - name: Test with pytest
+        run: ./.github/workflows/test.sh

--- a/.github/workflows/run_ci.sh
+++ b/.github/workflows/run_ci.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+sudo apt-get -qq install \
+    gcc \
+    libblas-dev \
+    cmake \
+    curl
+
+python -m pip install --upgrade pip
+pip install pytest
+pip install .
+
+

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+  
+set -e
+
+cd ./pyscf
+pytest -k 'not _slow'

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -2,5 +2,4 @@
   
 set -e
 
-cd ./pyscf
 pytest -c pytest.ini

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -2,4 +2,5 @@
   
 set -e
 
-pytest -c pytest.ini
+cd pyscf/nmr
+pytest .

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -2,5 +2,5 @@
   
 set -e
 
-cd pyscf/nmr
+cd pyscf/prop/nmr
 pytest .

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -3,4 +3,4 @@
 set -e
 
 cd ./pyscf
-pytest -k 'not _slow'
+pytest -c pytest.ini

--- a/pyscf/prop/nmr/test/test_hf_msc.py
+++ b/pyscf/prop/nmr/test/test_hf_msc.py
@@ -46,6 +46,14 @@ rhf.scf()
 def finger(mat):
     return abs(mat).sum()
 
+def proc_nmr_tensor(tsr):
+    tsr = (tsr + tsr.T) / 2
+    eigs = numpy.linalg.eigvalsh(tsr)
+    eigs.sort()
+    nmr_iso = eigs.sum() / 3
+    nmr_ani = eigs[2] - (eigs[0] + eigs[1]) / 2
+    return nmr_iso, nmr_ani
+
 class KnowValues(unittest.TestCase):
     def test_nr_common_gauge_ucpscf(self):
         m = nmr.RHF(nrhf)
@@ -136,6 +144,13 @@ class KnowValues(unittest.TestCase):
         self.assertAlmostEqual(numpy.linalg.norm(h1), 73.452535645731714, 8)
         h1 = nmr.dhf.make_h10(mol, dm0, gauge_orig=(0,0,0), mb='RKB')
         self.assertAlmostEqual(numpy.linalg.norm(h1), 7.3636964305440609, 8)
+
+    def test_nr_giao_uhf(self):
+        mol_spin2 = mol.copy().set(spin=2)
+        nruhf = mol_spin2.UHF().set(conv_tol=1e-12).run()
+        m = nmr.UHF(nruhf)
+        msc = m.shielding()
+        self.assertAlmostEqual(proc_nmr_tensor(msc[1])[0], -13739.422178310575, 6)
 
 
 

--- a/pyscf/prop/nmr/test/test_hf_msc.py
+++ b/pyscf/prop/nmr/test/test_hf_msc.py
@@ -150,7 +150,7 @@ class KnowValues(unittest.TestCase):
         nruhf = mol_spin2.UHF().set(conv_tol=1e-12).run()
         m = nmr.UHF(nruhf)
         msc = m.shielding()
-        self.assertAlmostEqual(proc_nmr_tensor(msc[1])[0], -13739.422178310575, 6)
+        self.assertAlmostEqual(proc_nmr_tensor(msc[1])[0], -13739.422178310575, 4)
 
 
 

--- a/pyscf/prop/nmr/uhf.py
+++ b/pyscf/prop/nmr/uhf.py
@@ -200,8 +200,11 @@ def gen_vind(mf, mo_coeff, mo_occ):
         v1ao = vresp(dm1)
         v1a = [reduce(numpy.dot, (mo_coeff[0].T.conj(), x, orboa)) for x in v1ao[0]]
         v1b = [reduce(numpy.dot, (mo_coeff[1].T.conj(), x, orbob)) for x in v1ao[1]]
-        v1mo = numpy.hstack((numpy.asarray(v1a),
-                             numpy.asarray(v1b)))
+        nset = mo1a.shape[0]
+        v1mo = numpy.hstack((numpy.asarray(v1a).reshape(nset,-1),
+                             numpy.asarray(v1b).reshape(nset,-1)))
+        # v1mo = numpy.hstack((numpy.asarray(v1a),
+        #                      numpy.asarray(v1b)))
         return v1mo.ravel()
     return vind
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --import-mode=importlib
+  -k "not _high_cost and not _skip"
+  --ignore=examples
+  --ignore-glob="*_slow*.py"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --import-mode=importlib
+addopts = 
   -k "not _high_cost and not _skip"
   --ignore=examples
   --ignore-glob="*_slow*.py"


### PR DESCRIPTION
In #11 we found that the hstack in uhf nmr get_vind is incorrect for na != nb. I'm not very sure about what's the correct concatenation. After looking at pyscf's ucphf 

https://github.com/pyscf/pyscf/blob/e8642fb7220248bd750c34ef6adf88a9744977ee/pyscf/scf/ucphf.py#L131

I think it's like reshape-last-two-dim-then-hstack. And this fix is verified by 1) pass the na=nb test 2) comparison with Gaussian, although getting not very exact match.